### PR TITLE
Shrink mobile header footprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# SNDP Unit 9 — Website (GitHub Pages)
+# SNDP Chathenkery — Website (GitHub Pages)
 
-Clean, Wikipedia‑style site for SNDP Unit 9 with a **Directory**, **Loan Portal**, and **User Detail** pages.  
+Clean, interactive site for SNDP Chathenkery with a **Directory**, **Loan Portal**, and **User Detail** pages.
 This starter splits **HTML/CSS/JS** and moves all demo data to **JSON** so you can update content without touching code.
 
 ## 🌐 Live (GitHub Pages)
@@ -29,7 +29,7 @@ After pushing to `main`, enable Pages in **Settings ▸ Pages**. Use the **root*
 │     └─ directory.js      # directory page (public contact listing)
 ├─ data/
 │  ├─ site.json            # site settings & nav labels
-│  ├─ users.json           # demo users (manager + 10 users, Ezhava names)
+│  ├─ users.json           # demo users (manager + 10 users, Chathenkery addresses)
 │  ├─ events.json          # events
 │  └─ notices.json         # notices
 ├─ schemas/

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,58 +1,202 @@
 :root{
-  --bg:#0b1220; --panel:#0f1a2b; --muted:#a8b5c6; --text:#eaf2ff;
-  --brand:#06b6d4; --brand2:#4dd4ac; --link:#82c8ff;
-  --ok:#22c55e; --warn:#f59e0b; --shadow:0 10px 30px rgba(0,0,0,.18);
-  --radius:16px; --radius-lg:22px; --content-w:1200px;
+  --bg:#fff9db;
+  --bg-gradient:radial-gradient(1200px 600px at 10% -10%, #fff3ad 0%, #ffe082 45%, #ffd166 100%);
+  --panel:#fff4c3;
+  --panel-strong:#ffe38b;
+  --muted:#8c6b1f;
+  --text:#3f2d00;
+  --brand:#f59e0b;
+  --brand2:#facc15;
+  --link:#b45309;
+  --ok:#15803d;
+  --warn:#ea580c;
+  --border:rgba(244,182,25,.5);
+  --shadow:0 18px 36px rgba(212,163,21,.22);
+  --shadow-strong:0 28px 48px rgba(212,163,21,.32);
+  --radius:16px;
+  --radius-lg:24px;
+  --content-w:1200px;
+  --input-bg:rgba(255,255,255,.75);
+  --tile-bg:linear-gradient(180deg,rgba(255,255,255,.95),rgba(255,255,255,.68));
 }
-*{box-sizing:border-box} html,body{height:100%} body{margin:0;background:radial-gradient(1200px 600px at 10% -10%, #12223d 0%, #0b1220 50%, #08101c 100%);color:var(--text);font-family:ui-sans-serif,system-ui,Segoe UI,Inter,Roboto,Helvetica,Arial}
-.wrap{max-width:var(--content-w);margin:0 auto;padding:20px}
-.topbar{position:sticky;top:0;z-index:50;backdrop-filter:saturate(1.1) blur(10px);background:linear-gradient(180deg,rgba(10,18,32,.92),rgba(10,18,32,.65));border-bottom:1px solid rgba(255,255,255,.06);display:flex;gap:16px;align-items:center;justify-content:space-between;padding:14px 18px}
-.brand{display:flex;align-items:center;gap:12px;color:var(--text);text-decoration:none}
-.logo{width:40px;height:40px;border-radius:12px;box-shadow:var(--shadow);background:conic-gradient(from 180deg at 50% 50%,#06b6d4,#4dd4ac,#82c8ff,#06b6d4);display:grid;place-items:center;font-weight:800;color:#052430}
-.nav{display:flex;flex-wrap:wrap;gap:8px}
-.nav a{color:var(--text);text-decoration:none;font-weight:600;font-size:14px;padding:8px 12px;border-radius:10px;border:1px solid rgba(255,255,255,.08);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02))}
-.nav a.active{outline:2px solid var(--brand);box-shadow:0 0 0 4px rgba(6,182,212,.12)}
-.tools{display:flex;gap:8px;align-items:center}
-.btn{cursor:pointer;padding:8px 12px;border-radius:10px;border:1px solid rgba(255,255,255,.12);background:rgba(255,255,255,.06);color:var(--text);font-weight:600}
-.hero{margin:18px auto 22px;padding:18px;border-radius:var(--radius-lg);background:linear-gradient(180deg,#0c1f39,#0a1730);box-shadow:var(--shadow);border:1px solid rgba(255,255,255,.06)}
-.hero-inner{display:grid;grid-template-columns:1.1fr .9fr;gap:20px}
-.hero .home-article{margin-top:18px}
-.hero .home-article .quote{margin-top:10px}
-.kpi{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin:12px 0}
-.tile{padding:14px;border-radius:14px;border:1px solid rgba(255,255,255,.08);background:linear-gradient(180deg,rgba(255,255,255,.04),rgba(255,255,255,.02))}
-.tile .big{font-weight:800;font-size:24px}
-.tile .sub{color:var(--muted)}
-.stat-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px;margin:10px 0 4px}
-.stat-grid .tile{background:linear-gradient(180deg,rgba(130,200,255,.08),rgba(130,200,255,.02));border-color:rgba(130,200,255,.18)}
-.notice{display:flex;gap:12px;align-items:flex-start;padding:10px 12px;margin:10px 0;border-radius:12px;border:1px solid rgba(255,255,255,.12)}
-.notice.ok{background:rgba(34,197,94,.08);border-color:rgba(34,197,94,.28)}
-.notice .dot{width:10px;height:10px;border-radius:50%;background:var(--ok)}
-.gallery{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:12px}
-.gallery figure{margin:0}
-.gallery-card{height:100%;display:flex;flex-direction:column;gap:10px;padding:16px;border-radius:14px;border:1px solid rgba(255,255,255,.08);background:linear-gradient(180deg,rgba(77,212,172,.08),rgba(12,31,57,.5))}
-.gallery-card h3{margin:0;font-size:18px;font-weight:700;color:var(--text)}
-.gallery-card p{margin:0;line-height:1.55;color:var(--text)}
-.gallery-card a{color:var(--link);font-weight:600;text-decoration:none}
-.gallery-card a:hover{text-decoration:underline}
-.footer{text-align:center;color:#a8b5c6;margin:30px 0 40px}
-.table{width:100%;border-collapse:collapse}
-.table th,.table td{padding:10px;border-bottom:1px solid rgba(255,255,255,.08);text-align:left;white-space:nowrap}
-.table thead th{position:sticky;top:0;background:rgba(255,255,255,.04)}
-.article{display:flex;flex-direction:column;gap:14px;padding:18px;border-radius:var(--radius);background:linear-gradient(180deg,rgba(255,255,255,.04),rgba(255,255,255,.01));border:1px solid rgba(255,255,255,.08);box-shadow:var(--shadow)}
-.article p{margin:0;line-height:1.6;color:var(--text)}
-
-.fact-list{list-style:none;margin:0;padding:0;display:grid;gap:8px}
-.fact-list li{padding:10px;border-radius:10px;background:rgba(130,200,255,.08);border:1px solid rgba(130,200,255,.2);color:var(--text)}
-.fact-list li strong{display:block;color:var(--link);font-size:13px;margin-bottom:2px}
-.timeline{list-style:none;margin:0;padding:0;display:grid;gap:12px}
-.timeline li{display:grid;grid-template-columns:90px 1fr;gap:12px;align-items:start;padding:12px;border-radius:12px;background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.08)}
-.timeline .year{font-weight:800;color:var(--link)}
-.bullet-list{margin:0;padding-left:20px;display:grid;gap:8px}
-
-.quote{margin:0;border-left:4px solid var(--brand);padding-left:12px;font-style:italic;color:var(--link)}
-.faq{display:grid;gap:10px}
-.faq details{background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.08);border-radius:12px;padding:10px}
-.faq summary{font-weight:700;cursor:pointer}
-.faq p{margin:8px 0 0;color:var(--text)}
-
-@media (max-width:980px){.hero-inner{grid-template-columns:1fr}.kpi{grid-template-columns:repeat(2,1fr)}}
+body{
+  margin:0;
+  min-height:100%;
+  background:var(--bg-gradient);
+  color:var(--text);
+  font-family:"Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+  transition:background .3s ease, color .3s ease;
+}
+body[data-theme="dark"]{
+  --bg:#0b1220;
+  --bg-gradient:radial-gradient(1200px 600px at 10% -10%, #12223d 0%, #0b1220 50%, #08101c 100%);
+  --panel:#0f1a2b;
+  --panel-strong:#13233a;
+  --muted:#a8b5c6;
+  --text:#eaf2ff;
+  --brand:#06b6d4;
+  --brand2:#4dd4ac;
+  --link:#82c8ff;
+  --ok:#22c55e;
+  --warn:#f59e0b;
+  --border:rgba(255,255,255,.14);
+  --shadow:0 12px 30px rgba(0,0,0,.35);
+  --shadow-strong:0 24px 60px rgba(0,0,0,.48);
+  --input-bg:rgba(16,25,40,.9);
+  --tile-bg:linear-gradient(180deg,rgba(255,255,255,.08),rgba(255,255,255,.04));
+}
+a{color:var(--link);text-decoration:none;transition:color .2s ease;}
+a:hover{color:var(--brand);}
+.wrap{max-width:var(--content-w);margin:0 auto;padding:20px;display:block;}
+.topbar{position:sticky;top:0;z-index:50;backdrop-filter:saturate(1.2) blur(12px);background:rgba(255,255,255,.84);border-bottom:1px solid var(--border);display:flex;gap:16px;align-items:center;justify-content:space-between;padding:14px 18px;box-shadow:0 10px 30px rgba(209,153,18,.18);}
+body[data-theme="dark"] .topbar{background:rgba(9,16,29,.92);box-shadow:0 10px 30px rgba(0,0,0,.45);}
+.brand{display:flex;align-items:center;gap:12px;color:var(--text);font-weight:700;font-size:18px;}
+.logo{width:44px;height:44px;border-radius:14px;box-shadow:var(--shadow);background:conic-gradient(from 180deg at 50% 50%,var(--brand),var(--brand2),#ffe082,var(--brand));display:grid;place-items:center;font-weight:800;color:#4c2a00;}
+body[data-theme="dark"] .logo{color:#052430;}
+.nav{display:flex;flex-wrap:wrap;gap:8px;align-items:center;}
+.nav a{color:var(--text);text-decoration:none;font-weight:600;font-size:14px;padding:8px 14px;border-radius:12px;border:1px solid var(--border);background:linear-gradient(180deg,rgba(255,255,255,.92),rgba(255,255,255,.62));box-shadow:0 6px 12px rgba(209,153,18,.16);transition:transform .2s ease, box-shadow .2s ease, background .2s ease;}
+.nav a:hover{transform:translateY(-2px);box-shadow:var(--shadow);}
+.nav a.active{outline:2px solid var(--brand);box-shadow:0 0 0 4px rgba(245,158,11,.22);}
+body[data-theme="dark"] .nav a{background:linear-gradient(180deg,rgba(255,255,255,.08),rgba(255,255,255,.02));box-shadow:none;}
+.menu-toggle{display:none;align-items:center;gap:8px;padding:8px 14px;border-radius:12px;border:1px solid var(--border);background:linear-gradient(180deg,rgba(255,255,255,.95),rgba(255,255,255,.7));color:var(--text);font-weight:600;cursor:pointer;box-shadow:0 6px 12px rgba(209,153,18,.16);transition:transform .2s ease, box-shadow .2s ease, background .2s ease;}
+.menu-toggle:hover{transform:translateY(-2px);box-shadow:var(--shadow);}
+.menu-toggle:focus{outline:2px solid var(--brand2);box-shadow:0 0 0 4px rgba(244,182,25,.2);}
+.search-toggle{display:none;align-items:center;gap:6px;}
+.search-icon{display:inline-block;width:14px;height:14px;border:2px solid var(--text);border-radius:50%;position:relative;transition:background .2s ease, border-color .2s ease;}
+.search-icon::after{content:"";position:absolute;width:8px;height:2px;background:var(--text);border-radius:999px;transform:rotate(45deg);right:-5px;bottom:-3px;transition:background .2s ease;}
+body[data-theme="dark"] .search-icon{border-color:var(--text);}
+body[data-theme="dark"] .search-icon::after{background:var(--text);}
+.menu-icon{position:relative;display:block;width:18px;height:2px;background:var(--text);border-radius:999px;transition:transform .2s ease, background .2s ease;}
+.menu-icon::before,.menu-icon::after{content:"";position:absolute;left:0;width:18px;height:2px;background:var(--text);border-radius:999px;transition:transform .2s ease, opacity .2s ease;}
+.menu-icon::before{top:-6px;}
+.menu-icon::after{top:6px;}
+body[data-nav-open="true"] .menu-icon{background:transparent;}
+body[data-nav-open="true"] .menu-icon::before{transform:translateY(6px) rotate(45deg);}
+body[data-nav-open="true"] .menu-icon::after{transform:translateY(-6px) rotate(-45deg);}
+body[data-nav-open="true"] .menu-toggle{box-shadow:var(--shadow);}
+.tools{display:flex;gap:8px;align-items:center;}
+.search input, input, textarea{background:var(--input-bg);border:1px solid var(--border);border-radius:12px;padding:8px 12px;color:var(--text);font-size:14px;transition:border .2s ease, box-shadow .2s ease;}
+input:focus, textarea:focus{outline:2px solid var(--brand2);box-shadow:0 0 0 4px rgba(244,182,25,.2);}
+body[data-theme="dark"] .search input, body[data-theme="dark"] input, body[data-theme="dark"] textarea{color:var(--text);}
+.btn{cursor:pointer;padding:10px 16px;border-radius:12px;border:1px solid var(--border);background:linear-gradient(180deg,rgba(255,255,255,.95),rgba(255,255,255,.55));color:var(--text);font-weight:600;box-shadow:0 8px 16px rgba(209,153,18,.2);transition:transform .2s ease, box-shadow .2s ease, background .2s ease, color .2s ease;}
+.btn:hover{transform:translateY(-2px);box-shadow:var(--shadow);}
+.btn:active{transform:translateY(0);}
+.btn-alt{background:linear-gradient(180deg,var(--brand2),var(--brand));color:#4d2c00;}
+body[data-theme="dark"] .btn{background:rgba(255,255,255,.08);box-shadow:none;}
+body[data-theme="dark"] .btn-alt{color:var(--text);}
+.hero{margin:20px auto 24px;padding:24px;border-radius:var(--radius-lg);background:linear-gradient(180deg,rgba(255,255,255,.9),rgba(255,247,199,.9));box-shadow:var(--shadow);border:1px solid var(--border);}
+body[data-theme="dark"] .hero{background:linear-gradient(180deg,#0c1f39,#0a1730);}
+.hero-inner{display:grid;grid-template-columns:1.1fr .9fr;gap:24px;align-items:start;}
+.hero-copy{display:flex;flex-direction:column;gap:14px;}
+.eyebrow{font-size:12px;letter-spacing:.16em;text-transform:uppercase;color:var(--muted);font-weight:700;}
+.hero-copy h1{margin:0;font-size:36px;line-height:1.1;}
+.hero-copy p{margin:0;font-size:17px;line-height:1.6;color:var(--text);}
+.chips{display:flex;flex-wrap:wrap;gap:8px;margin:4px 0 10px;}
+.chip{display:inline-flex;align-items:center;padding:6px 12px;border-radius:999px;background:rgba(255,255,255,.85);color:var(--text);font-weight:600;border:1px solid rgba(244,182,25,.45);box-shadow:0 6px 12px rgba(209,153,18,.16);}
+body[data-theme="dark"] .chip{background:rgba(12,31,57,.85);border-color:rgba(255,255,255,.12);box-shadow:none;}
+.cta{display:flex;flex-wrap:wrap;gap:10px;margin-top:6px;}
+.hero-spot{display:flex;flex-direction:column;gap:16px;}
+.kpi{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:14px;}
+.tile{padding:16px;border-radius:18px;border:1px solid var(--border);background:var(--tile-bg);box-shadow:0 10px 24px rgba(209,153,18,.18);transition:transform .2s ease, box-shadow .2s ease;}
+.tile:hover{transform:translateY(-3px);box-shadow:var(--shadow-strong);}
+.tile .big{font-weight:800;font-size:26px;}
+.tile .sub{color:var(--muted);font-weight:600;text-transform:uppercase;font-size:12px;letter-spacing:.08em;}
+.tile p{margin:8px 0 0;font-size:13px;color:var(--muted);}
+.stat-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:14px;margin:10px 0 4px;}
+.notice{display:flex;gap:12px;align-items:flex-start;padding:14px 16px;border-radius:16px;border:1px solid var(--border);background:rgba(255,255,255,.92);box-shadow:0 12px 24px rgba(209,153,18,.16);color:var(--text);}
+.notice .dot{width:12px;height:12px;border-radius:50%;background:var(--ok);margin-top:6px;}
+.notice.ok{background:rgba(21,128,61,.12);border-color:rgba(21,128,61,.35);box-shadow:none;}
+.notice.warn{background:rgba(234,88,12,.14);border-color:rgba(234,88,12,.35);}
+body[data-theme="dark"] .notice{background:rgba(255,255,255,.08);box-shadow:none;}
+body[data-theme="dark"] .notice.ok{background:rgba(34,197,94,.12);}
+.home-highlights{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:18px;margin-top:24px;}
+.highlight-card{padding:18px;border-radius:18px;border:1px solid var(--border);background:var(--tile-bg);box-shadow:0 12px 24px rgba(209,153,18,.18);display:flex;flex-direction:column;gap:10px;transition:transform .2s ease, box-shadow .2s ease;}
+.highlight-card:hover{transform:translateY(-4px);box-shadow:var(--shadow-strong);}
+.highlight-card h3{margin:0;font-size:20px;}
+.highlight-card p{margin:0;color:var(--text);line-height:1.6;}
+.highlight-card a{align-self:flex-start;font-weight:700;}
+.home-insights{margin-top:24px;display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:18px;}
+.insight-card{padding:18px;border-radius:18px;border:1px solid var(--border);background:var(--tile-bg);box-shadow:0 12px 24px rgba(209,153,18,.18);display:flex;flex-direction:column;gap:10px;}
+.insight-card h3{margin:0;font-size:18px;}
+.insight-card ul{margin:0;padding-left:18px;display:grid;gap:6px;color:var(--text);}
+.gallery{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:16px;}
+.gallery figure{margin:0;}
+.gallery-card{height:100%;display:flex;flex-direction:column;gap:10px;padding:18px;border-radius:18px;border:1px solid var(--border);background:var(--tile-bg);box-shadow:0 10px 22px rgba(209,153,18,.16);}
+.gallery-card h3{margin:0;font-size:18px;font-weight:700;color:var(--text);}
+.gallery-card p{margin:0;line-height:1.55;color:var(--text);}
+.gallery-card a{color:var(--link);font-weight:600;}
+.gallery-card a:hover{text-decoration:underline;}
+.footer{text-align:center;color:var(--muted);margin:30px 0 40px;}
+.table{width:100%;border-collapse:collapse;box-shadow:0 10px 24px rgba(209,153,18,.12);border-radius:18px;overflow:hidden;}
+.table th,.table td{padding:12px;border-bottom:1px solid var(--border);text-align:left;white-space:nowrap;color:var(--text);background:rgba(255,255,255,.9);}
+.table thead th{position:sticky;top:0;background:rgba(255,255,255,.92);font-size:13px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);}
+body[data-theme="dark"] .table th, body[data-theme="dark"] .table td{background:rgba(255,255,255,.04);}
+body[data-theme="dark"] .table thead th{background:rgba(255,255,255,.08);}
+.article{display:flex;flex-direction:column;gap:16px;padding:22px;border-radius:var(--radius);background:var(--tile-bg);border:1px solid var(--border);box-shadow:0 12px 24px rgba(209,153,18,.16);}
+.article p{margin:0;line-height:1.7;color:var(--text);}
+.article .btn{align-self:flex-start;}
+.fact-list{list-style:none;margin:0;padding:0;display:grid;gap:10px;}
+.fact-list li{padding:12px;border-radius:12px;background:rgba(255,255,255,.85);border:1px solid var(--border);color:var(--text);box-shadow:0 6px 12px rgba(209,153,18,.16);}
+.fact-list li strong{display:block;color:var(--link);font-size:13px;margin-bottom:2px;}
+body[data-theme="dark"] .fact-list li{background:rgba(255,255,255,.06);box-shadow:none;}
+.timeline{list-style:none;margin:0;padding:0;display:grid;gap:14px;}
+.timeline li{display:grid;grid-template-columns:110px 1fr;gap:12px;align-items:start;padding:14px;border-radius:14px;background:var(--tile-bg);border:1px solid var(--border);box-shadow:0 8px 18px rgba(209,153,18,.14);}
+.timeline .year{font-weight:800;color:var(--brand);}
+.bullet-list{margin:0;padding-left:20px;display:grid;gap:8px;color:var(--text);}
+.quote{margin:0;border-left:4px solid var(--brand);padding-left:12px;font-style:italic;color:var(--link);}
+.faq{display:grid;gap:12px;}
+.faq details{background:var(--tile-bg);border:1px solid var(--border);border-radius:14px;padding:14px;box-shadow:0 8px 16px rgba(209,153,18,.12);}
+.faq summary{font-weight:700;cursor:pointer;}
+.faq p{margin:8px 0 0;color:var(--text);}
+.table-wrap{overflow:auto;border-radius:18px;}
+@media (max-width:1100px){
+  .hero-copy h1{font-size:32px;}
+}
+@media (max-width:900px){
+  .hero-inner{grid-template-columns:1fr;}
+  .wrap{padding:16px;}
+}
+@media (max-width:820px){
+  .topbar{flex-wrap:wrap;align-items:center;gap:10px;padding:10px 14px;}
+  .brand{font-size:16px;gap:10px;}
+  .logo{width:38px;height:38px;}
+  .menu-toggle{display:flex;order:3;padding:8px 10px;}
+  .menu-toggle .menu-label{display:none;}
+  .tools{order:2;flex:1 1 auto;width:auto;display:flex;align-items:center;justify-content:flex-end;gap:6px;position:relative;flex-wrap:nowrap;}
+  .tools .btn{flex:0 0 auto;width:auto;text-align:center;padding:8px 12px;font-size:13px;box-shadow:0 4px 12px rgba(209,153,18,.16);}
+  #userPanel{flex:0 0 auto;display:flex;gap:6px;align-items:center;}
+  #userPanel .btn{flex:0 0 auto;}
+  .search-toggle{display:inline-flex;}
+  .search-text{display:inline;}
+  .tools .search{display:none;position:absolute;left:0;right:0;top:calc(100% + 10px);padding:12px;border-radius:14px;background:linear-gradient(180deg,rgba(255,255,255,.95),rgba(255,255,255,.7));box-shadow:0 14px 28px rgba(209,153,18,.22);border:1px solid var(--border);z-index:60;}
+  body[data-theme="dark"] .tools .search{background:rgba(12,23,40,.96);box-shadow:0 14px 30px rgba(0,0,0,.55);}
+  .tools .search input{width:100%;}
+  body[data-search-open="true"] .tools .search{display:flex;}
+  body[data-search-open="true"] .topbar{padding-bottom:92px;}
+  .nav{order:4;width:100%;display:none;flex-direction:column;align-items:stretch;padding:12px;border-radius:16px;background:rgba(255,255,255,.92);box-shadow:0 12px 24px rgba(209,153,18,.18);}
+  body[data-theme="dark"] .nav{background:rgba(12,23,40,.92);box-shadow:0 12px 24px rgba(0,0,0,.45);}
+  body[data-nav-open="true"] .nav{display:flex;}
+  .nav a{width:100%;justify-content:space-between;font-size:15px;}
+  .cta{width:100%;}
+  .btn{width:100%;text-align:center;}
+  .notice{flex-direction:column;align-items:flex-start;}
+}
+@media (max-width:640px){
+  .hero{padding:20px;}
+  .hero-copy h1{font-size:28px;}
+  .hero-copy p{font-size:16px;}
+  .chips{gap:6px;}
+  .tile .big{font-size:22px;}
+  .insight-card h3{font-size:17px;}
+  .gallery-card{padding:16px;}
+}
+@media (max-width:520px){
+  .topbar{padding:9px 12px;}
+  .logo{width:34px;height:34px;}
+  .brand span{font-size:15px;}
+  .search-text{display:none;}
+  .hero{padding:18px;}
+  .hero-copy h1{font-size:26px;}
+  .timeline li{grid-template-columns:1fr;}
+  .timeline .year{font-size:16px;}
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,4 +1,4 @@
-import { loadJSON, store } from "./util.js";
+import { loadJSON, store, safe } from "./util.js";
 import { renderRoute, currentRoute } from "./router.js";
 import { bindAuthButtons, refreshAuthUI, setSession, getSession } from "./auth.js";
 import { renderLoans, renderUserDetail } from "./loans.js";
@@ -7,6 +7,50 @@ import { CONTENT, renderStaticContent } from "./content.js";
 
 let DATA = { accounts: [], events: [], notices: [], site: {} };
 let searchBlocks = [];
+
+function openSearchPanel(){
+  document.body.dataset.searchOpen = "true";
+  const toggle = document.getElementById("searchToggle");
+  if(toggle){
+    toggle.setAttribute("aria-expanded", "true");
+    const text = toggle.querySelector(".search-text");
+    if(text && window.innerWidth <= 820){
+      text.textContent = "Close";
+    }
+  }
+  const q = document.getElementById("q");
+  if(q){
+    if(window.innerWidth <= 820){
+      setTimeout(()=> q.focus(), 50);
+    } else {
+      q.focus();
+    }
+  }
+}
+
+function closeSearchPanel(){
+  document.body.dataset.searchOpen = "false";
+  const toggle = document.getElementById("searchToggle");
+  if(toggle){
+    toggle.setAttribute("aria-expanded", "false");
+    const text = toggle.querySelector(".search-text");
+    if(text){
+      text.textContent = "Search";
+    }
+  }
+  const q = document.getElementById("q");
+  if(q && document.activeElement === q){
+    q.blur();
+  }
+}
+
+function toggleSearchPanel(){
+  if(document.body.dataset.searchOpen === "true"){
+    closeSearchPanel();
+  } else {
+    openSearchPanel();
+  }
+}
 
 async function bootstrap(){
   // Load data in parallel
@@ -22,11 +66,19 @@ async function bootstrap(){
   DATA.site     = site;
 
   document.getElementById("year").textContent = new Date().getFullYear();
-  document.body.dataset.theme = DATA.site.theme || "dark";
+  const storedTheme = store.get("theme");
+  const initialTheme = storedTheme || DATA.site.theme || "light";
+  document.body.dataset.theme = initialTheme;
+  document.body.dataset.navOpen = "false";
+  document.body.dataset.searchOpen = "false";
   refreshAuthUI();
   bindAuthButtons();
 
   renderStaticContent(CONTENT, DATA.events);
+  renderHome(DATA.site);
+  renderSectionIntros(DATA.site);
+  renderGallery(DATA.site);
+  renderReferences(DATA.site);
   searchBlocks = Array.from(document.querySelectorAll("section[data-route], section.hero"));
 
   // Basic notices/events render
@@ -45,7 +97,23 @@ async function bootstrap(){
 
   // Search shortcut
   const q = document.getElementById("q");
-  document.addEventListener("keydown", (e)=>{ if(e.key === "/" && document.activeElement !== q){ e.preventDefault(); q.focus(); }});
+  const searchToggle = document.getElementById("searchToggle");
+  closeSearchPanel();
+  searchToggle?.addEventListener("click", toggleSearchPanel);
+  document.addEventListener("keydown", (e)=>{
+    if(e.key === "/" && document.activeElement !== q){
+      e.preventDefault();
+      if(window.innerWidth <= 820){
+        openSearchPanel();
+      } else {
+        q?.focus();
+      }
+    }
+    if(e.key === "Escape" && document.body.dataset.searchOpen === "true"){
+      e.preventDefault();
+      closeSearchPanel();
+    }
+  });
   q?.addEventListener("input", ()=>{
     const needle = q.value.trim().toLowerCase();
     if(!needle){ searchBlocks.forEach(b=> b.style.outline="none"); return; }
@@ -57,8 +125,45 @@ async function bootstrap(){
 
   // Theme toggle
   document.getElementById("theme")?.addEventListener("click", ()=>{
-    const dark = document.body.dataset.theme !== "light";
-    document.body.dataset.theme = dark ? "light" : "dark";
+    const next = document.body.dataset.theme === "dark" ? "light" : "dark";
+    document.body.dataset.theme = next;
+    store.set("theme", next);
+  });
+
+  // Navigation toggle
+  const navToggle = document.getElementById("navToggle");
+  const navLabel = navToggle?.querySelector(".menu-label");
+  const navLinks = document.querySelectorAll(".nav a");
+  const closeNav = ()=>{
+    document.body.dataset.navOpen = "false";
+    if(navToggle){
+      navToggle.setAttribute("aria-expanded", "false");
+      navToggle.classList.remove("is-open");
+    }
+    if(navLabel){
+      navLabel.textContent = "Menu";
+    }
+    closeSearchPanel();
+  };
+  navToggle?.addEventListener("click", ()=>{
+    const isOpen = document.body.dataset.navOpen === "true";
+    const next = !isOpen;
+    document.body.dataset.navOpen = String(next);
+    navToggle.setAttribute("aria-expanded", String(next));
+    navToggle.classList.toggle("is-open", next);
+    if(navLabel){
+      navLabel.textContent = next ? "Close" : "Menu";
+    }
+    if(next){
+      closeSearchPanel();
+    }
+  });
+  navLinks.forEach(link => link.addEventListener("click", closeNav));
+  window.addEventListener("resize", ()=>{
+    closeSearchPanel();
+    if(window.innerWidth > 820){
+      closeNav();
+    }
   });
 
   // Simple login page inside SPA
@@ -96,8 +201,131 @@ async function bootstrap(){
   });
 }
 
+function renderHome(site = {}){
+  const title = site.title || "SNDP Chathenkery";
+  document.title = site.pageTitle || `${title} — Community Hub`;
+  const metaDesc = document.querySelector('meta[name="description"]');
+  if(metaDesc && site.description){
+    metaDesc.setAttribute("content", site.description);
+  }
+  const brandLabel = document.querySelector(".brand span");
+  if(brandLabel) brandLabel.textContent = title;
+  const heroHeading = document.querySelector(".hero-copy h1");
+  if(heroHeading) heroHeading.textContent = `Welcome to ${title}`;
+  const mottoEl = document.getElementById("siteMotto");
+  if(mottoEl && site.motto){ mottoEl.textContent = site.motto; }
+  const chipsEl = document.getElementById("homeChips");
+  if(chipsEl && Array.isArray(site.chips) && site.chips.length){
+    chipsEl.innerHTML = site.chips.map(text => `<span class="chip">${safe(text)}</span>`).join("");
+  }
+  const statsEl = document.getElementById("homeStats");
+  if(statsEl && Array.isArray(site.stats)){
+    statsEl.innerHTML = site.stats.map((stat) => `
+      <div class="tile">
+        <div class="sub">${safe(stat.label)}</div>
+        <div class="big">${safe(stat.value)}</div>
+        ${stat.note ? `<p>${safe(stat.note)}</p>` : ""}
+      </div>`).join("");
+  }
+  const highlightsEl = document.getElementById("homeOverview");
+  if(highlightsEl){
+    const highlights = Array.isArray(site.highlights) ? site.highlights : [];
+    highlightsEl.innerHTML = highlights.map((item) => `
+      <article class="highlight-card">
+        <h3>${safe(item.title)}</h3>
+        <p>${safe(item.body)}</p>
+        ${item.link ? `<a href="${safe(item.link.href)}"${item.link.external ? " target=\"_blank\" rel=\"noopener\"" : ""}>${safe(item.link.label || "Learn more")}</a>` : ""}
+      </article>`).join("");
+    highlightsEl.style.display = highlights.length ? "grid" : "none";
+  }
+  const insightsEl = document.getElementById("homeInsights");
+  if(insightsEl){
+    const sections = Array.isArray(site.insights) ? site.insights : [];
+    insightsEl.innerHTML = sections.map((section) => `
+      <div class="insight-card">
+        <h3>${safe(section.title)}</h3>
+        <ul>${(section.items || []).map((item) => `<li>${safe(item)}</li>`).join("")}</ul>
+      </div>`).join("");
+    insightsEl.style.display = sections.length ? "grid" : "none";
+  }
+}
+
+function renderSectionIntros(site = {}){
+  const sections = [
+    ["directoryIntro", site.directoryIntro],
+    ["noticesIntro", site.noticesIntro],
+    ["galleryIntro", site.galleryIntro],
+    ["loansIntro", site.loansIntro]
+  ];
+  sections.forEach(([id, config]) => {
+    const target = document.getElementById(id);
+    if(!target) return;
+    if(!config){
+      target.innerHTML = "";
+      target.style.display = "none";
+      return;
+    }
+    const block = typeof config === "string" ? { paragraphs: [config] } : config;
+    const paragraphs = Array.isArray(block.paragraphs) ? block.paragraphs : [];
+    const list = Array.isArray(block.list) ? block.list : [];
+    let html = `<article class="article">`;
+    if(paragraphs.length){
+      html += paragraphs.map(text => `<p>${safe(text)}</p>`).join("");
+    }
+    if(block.note){
+      html += `<p>${safe(block.note)}</p>`;
+    }
+    if(list.length){
+      html += `<ul class="bullet-list">${list.map(item => `<li>${safe(item)}</li>`).join("")}</ul>`;
+    }
+    if(block.cta && block.cta.href){
+      const external = block.cta.external ? ' target="_blank" rel="noopener"' : "";
+      const variant = block.cta.variant === "alt" ? " btn-alt" : "";
+      html += `<a class="btn${variant}" href="${safe(block.cta.href)}"${external}>${safe(block.cta.label || "Learn more")}</a>`;
+    }
+    html += `</article>`;
+    target.innerHTML = html;
+    target.style.display = "";
+  });
+}
+
+function renderGallery(site = {}){
+  const grid = document.getElementById("galleryGrid");
+  if(grid){
+    const items = Array.isArray(site.gallery) ? site.gallery : [];
+    grid.innerHTML = items.map(item => `
+      <article class="gallery-card">
+        ${item.eyebrow ? `<span class="eyebrow">${safe(item.eyebrow)}</span>` : ""}
+        <h3>${safe(item.title)}</h3>
+        ${item.body ? `<p>${safe(item.body)}</p>` : ""}
+        ${item.link ? `<a href="${safe(item.link.href)}"${item.link.external ? ' target=\"_blank\" rel=\"noopener\"' : ""}>${safe(item.link.label || "View details")}</a>` : ""}
+      </article>`).join("");
+    grid.style.display = items.length ? "grid" : "none";
+  }
+}
+
+function renderReferences(site = {}){
+  const list = document.getElementById("referencesList");
+  if(list){
+    const refs = Array.isArray(site.references) ? site.references : [];
+    list.innerHTML = refs.map((ref) => `
+      <li>
+        <a href="${safe(ref.href)}" target="_blank" rel="noopener">${safe(ref.label || ref.href)}</a>
+        ${ref.note ? `<div>${safe(ref.note)}</div>` : ""}
+      </li>`).join("");
+    list.style.display = refs.length ? "block" : "none";
+  }
+  const intro = document.getElementById("referencesIntro");
+  if(intro){
+    intro.innerHTML = site.referencesIntro
+      ? `<article class="article"><p>${safe(site.referencesIntro)}</p></article>`
+      : "";
+  }
+}
+
 function onRoute(){
   renderRoute();
+  closeSearchPanel();
   const { root, param } = currentRoute();
   if(root === "directory") renderDirectory(DATA.accounts);
   if(root === "loans"){
@@ -107,6 +335,14 @@ function onRoute(){
   if(root === "user"){
     if(!getSession()){ location.hash = "#/login"; return; }
     renderUserDetail(DATA.accounts, param);
+  }
+  const navToggle = document.getElementById("navToggle");
+  if(navToggle){
+    document.body.dataset.navOpen = "false";
+    navToggle.setAttribute("aria-expanded", "false");
+    navToggle.classList.remove("is-open");
+    const label = navToggle.querySelector(".menu-label");
+    if(label) label.textContent = "Menu";
   }
 }
 

--- a/assets/js/content.js
+++ b/assets/js/content.js
@@ -1,83 +1,91 @@
 import { safe } from "./util.js";
 
-
 export const CONTENT = {
   about: {
     paragraphs: [
-      "Sree Narayana Dharma Paripalana (SNDP) Yogam is a social and religious organisation founded in May 1903 at Aruvippuram in the former princely state of Travancore to spread the egalitarian teachings of Sree Narayana Guru.",
-      "The Yogam works mainly among Kerala's Ezhava community, advocating education, organised temple management, and cooperative enterprise as instruments of social uplift. Headquartered in Kollam, it administers an extensive network of schools, colleges, hospitals, and industrial ventures across the state."
+      "Sree Narayana Dharma Paripalana (SNDP) Yogam is a reformist movement founded in May 1903 at Aruvippuram to advance Sree Narayana Guru's egalitarian teachings across Kerala.",
+      "The Yogam mobilised marginalised communities through temple management, modern education, and cooperative enterprise. Today it administers a wide span of schools, colleges, hospitals, and credit societies anchored in Kollam.",
+      "Centenary reports highlight the Yogam's focus on women-led self-help groups, microfinance, and skill-building hubs that combine spiritual practice with tangible social welfare." 
     ],
     highlights: [
-      { label: "Founders", value: "Sree Narayana Guru, Dr. Padmanabhan Palpu, Kumaran Asan" },
+      { label: "Founded", value: "May 1903 • Aruvippuram, Kerala" },
       { label: "Headquarters", value: "Kollam, Kerala, India" },
-      { label: "Motto", value: "One caste, one religion, one God, for humankind" }
-
+      { label: "Mission", value: "Equality, education, cooperative welfare" },
+      { label: "Institutions", value: "Schools, colleges, hospitals & co-ops across Kerala" }
     ]
   },
   guru: {
     paragraphs: [
-
-      "Sree Narayana Guru (1855–1928) was a philosopher, saint, and social reformer from Kerala who challenged caste-based exclusion through peaceful reform.",
-      "He consecrated a Shiva idol at Aruvippuram in 1888, established temples open to all castes, and founded schools to promote modern education. His message of non-violence, self-improvement, and universal brotherhood remains central to SNDP Yogam's vision."
+      "Sree Narayana Guru (1855–1928) was a philosopher, saint, and social reformer whose life work challenged caste exclusion through peaceful, rational reform.",
+      "He consecrated a Shiva idol at Aruvippuram in 1888, opened temples to all communities, and founded schools that emphasised literacy, vocational skills, and self-improvement.",
+      "Guru's teachings inspired mass movements such as the Vaikom Satyagraha and encouraged communities to \"educate, organise, and industrialise\" alongside spiritual practice." 
     ],
     quote: "One caste, one religion, one God, for humankind"
   },
   history: {
     timeline: [
       { year: "1855", detail: "Birth of Narayana Guru at Chempazhanthy near Thiruvananthapuram." },
-      { year: "1888", detail: "Guru consecrates a Shiva temple at Aruvippuram, a symbolic act against caste restrictions on temple entry." },
-      { year: "1903", detail: "SNDP Yogam registered as a charitable society to organise followers of Guru's teachings." },
-      { year: "1904", detail: "Poet Kumaran Asan becomes the first general secretary, framing the Yogam's early programmes." },
-      { year: "1928", detail: "Passing of Sree Narayana Guru; the Yogam expands its educational and cooperative initiatives." }
+      { year: "1888", detail: "Guru consecrates a Shiva idol at Aruvippuram, signalling temple access for all communities." },
+      { year: "1903", detail: "SNDP Yogam registers as a charitable society with Guru as patron and Kumaran Asan as founding secretary." },
+      { year: "1904", detail: "Launch of the Vivekodayam journal to circulate Guru's writings and cooperative economics." },
+      { year: "1924", detail: "SNDP members support the Vaikom Satyagraha, strengthening anti-caste campaigns in Travancore." },
+      { year: "1948", detail: "Sree Narayana College, Kollam opens under SNDP Yogam, expanding the movement into higher education." },
+      { year: "2003", detail: "Centenary programmes modernise housing, healthcare, and microfinance missions across Kerala." }
     ],
     paragraphs: [
-      "SNDP Yogam grew rapidly in the early twentieth century, organising branch unions (shakhas) across Travancore and Cochin to coordinate temple reforms and literacy campaigns.",
-      "Post-independence, the Yogam diversified into colleges, hospitals, and industrial cooperatives, retaining its reformist ethos while serving a statewide membership base."
-
+      "Branch unions (shakhas) across Travancore and Cochin coordinated temple reforms, literacy drives, and community banking under the Yogam's banner.",
+      "Post-independence, the Yogam diversified into professional colleges, hospitals, cooperative credit societies, and pilgrim services while continuing to advocate for social justice." 
     ]
   },
-  unit9: {
+  chathenkery: {
     paragraphs: [
-
-      "Unit 9 operates as a local branch within the wider SNDP Yogam federation, following the standard shakha structure described in Yogam records.",
-      "Members coordinate temple festivals, scholarship drives, and relief initiatives in Kollam, echoing the Yogam's emphasis on community-based uplift and voluntary service."],
+      "SNDP Chathenkery functions as a ward-level sakha within Chengannur Municipality in Alappuzha district, Kerala. The locality stretches along the Pamba River and links neighbourhoods between Thiruvalla and Chengannur town centres.",
+      "Chengannur is widely described as the \"Gateway to Sabarimala\", and Chathenkery volunteers operate pilgrim facilitation desks, first-aid booths, and travel guidance near the Chengannur Mahadevar Temple transit hub.",
+      "The unit also works with municipal teams on riverbank clean-ups, flood-relief logistics, scholarship mentoring, and digital literacy labs for students and entrepreneurs." 
+    ],
     focus: [
-      { label: "Membership", value: "Open to devotees and well-wishers aligned with the Guru's ideals." },
-      { label: "Activities", value: "Temple stewardship, cultural programmes, education support, and microfinance." },
-      { label: "Service Area", value: "Neighbourhoods across central Kollam." }
-
+      { label: "Service Area", value: "Chathenkery ward & riverfront clusters in Chengannur Municipality" },
+      { label: "Signature Programmes", value: "Pilgrim transit support, Pamba river stewardship, cooperative thrift groups" },
+      { label: "Community Facilities", value: "SNDP hall near Chengannur Mahadevar Temple, reading room, skill lab" },
+      { label: "Membership", value: "Families, youth, and women's wings coordinating outreach to 150+ households" }
     ]
   },
   programs: {
     paragraphs: [
-
-      "According to SNDP Yogam's published activities, the organisation runs educational institutions from primary schools to colleges, along with industrial training centres and hospitals.",
-      "The Yogam also manages cooperative societies, credit unions, and self-help groups that provide financial services and employment support to its members." ],
+      "SNDP Yogam runs educational institutions from primary schools to colleges, alongside industrial training centres, hospitals, and cooperative banks across Kerala.",
+      "Chathenkery adapts these models locally through women-led self-help collectives, farmland support groups, pilgrim transit operations, and digital literacy labs aligned with municipal priorities." 
+    ],
     initiatives: [
-      "Educational trusts and colleges in Kerala's major districts.",
-      "Temple administration boards promoting inclusive worship.",
-      "Welfare programmes for students, women, and elderly members.",
-      "Cooperative ventures in coir, dairy, and small-scale industries." ],
-    upcomingHeading: "Upcoming community programmes"
+      "Pilgrim assistance kiosks during the Sabarimala season at Chengannur transport hubs.",
+      "Pamba river clean-up squads with flood preparedness drills and water-quality monitoring.",
+      "Scholarship mentoring and digital learning pods for school and college students.",
+      "Women's microfinance circles and livelihood training for home-based entrepreneurs.",
+      "Health outreach camps and elder-care visits in partnership with SNDP-run hospitals." 
+    ],
+    upcomingHeading: "Seasonal community programmes"
   },
-
   faq: {
     items: [
       {
         q: "What is the core aim of SNDP Yogam?",
-
-        a: "To uphold Sree Narayana Guru's ideals of social equality, spiritual progress, and self-reliance among Kerala's marginalised communities."
+        a: "To uphold Sree Narayana Guru's ideals of social equality, spiritual progress, and community self-reliance across Kerala." 
       },
       {
-        q: "Who can join a local unit?",
-        a: "Membership is generally open to devotees and supporters who agree to the Yogam's constitution and participate in branch activities."
+        q: "Who can join SNDP Chathenkery?",
+        a: "Membership is open to devotees, residents, and well-wishers who subscribe to the Yogam constitution and volunteer with ward-level initiatives." 
       },
       {
-        q: "How does the Yogam fund its initiatives?",
-        a: "Funding comes from member subscriptions, donations, income from institutions, and cooperative enterprises managed under the Yogam." },
+        q: "How does the Chathenkery unit serve pilgrims?",
+        a: "Volunteers maintain information desks, first-aid, and refreshment support around Chengannur's \"Gateway to Sabarimala\" transit points during peak season." 
+      },
       {
-        q: "What is the significance of the Guru's motto?",
-        a: "The motto \"One caste, one religion, one God, for humankind\" summarises Narayana Guru's call for equality and universal brotherhood beyond caste barriers." }
+        q: "How are local programmes funded?",
+        a: "Funding combines member subscriptions, donations, cooperative income, and project grants routed through SNDP Yogam's district offices." 
+      },
+      {
+        q: "What training is offered to youth members?",
+        a: "Weekly study circles cover Guru's teachings, digital skills, and disaster-preparedness drills linked to the Pamba river stewardship plan." 
+      }
     ]
   }
 };
@@ -97,7 +105,6 @@ export const renderStaticContent = (content, events = []) => {
       `<article class="article">${content.about.paragraphs.map(paraHTML).join("")}` +
         (content.about.highlights
           ? `<ul class="fact-list">${content.about.highlights.map(factHTML).join("")}</ul>`
-
           : "") +
         `</article>`
     );
@@ -106,12 +113,10 @@ export const renderStaticContent = (content, events = []) => {
   if (content.guru) {
     fill(
       "guru",
-
       `<article class="article">${content.guru.paragraphs.map(paraHTML).join("")}` +
         (content.guru.quote
           ? `<blockquote class="quote">${safe(content.guru.quote)}</blockquote>`
           : "") +
-
         `</article>`
     );
   }
@@ -120,24 +125,20 @@ export const renderStaticContent = (content, events = []) => {
     fill(
       "history",
       `<article class="article">` +
-
         `<ul class="timeline">${content.history.timeline
           .map((item) => `<li><span class="year">${safe(item.year)}</span><span>${safe(item.detail)}</span></li>`)
           .join("")}</ul>` +
         content.history.paragraphs.map(paraHTML).join("") +
-
         `</article>`
     );
   }
 
-  if (content.unit9) {
+  if (content.chathenkery) {
     fill(
-      "unit9",
-
-      `<article class="article">${content.unit9.paragraphs.map(paraHTML).join("")}` +
-        (content.unit9.focus
-          ? `<ul class="fact-list">${content.unit9.focus.map(factHTML).join("")}</ul>`
-
+      "chathenkery",
+      `<article class="article">${content.chathenkery.paragraphs.map(paraHTML).join("")}` +
+        (content.chathenkery.focus
+          ? `<ul class="fact-list">${content.chathenkery.focus.map(factHTML).join("")}</ul>`
           : "") +
         `</article>`
     );
@@ -155,17 +156,14 @@ export const renderStaticContent = (content, events = []) => {
 
     fill(
       "programs",
-
       `<article class="article">${content.programs.paragraphs.map(paraHTML).join("")}` +
         (content.programs.initiatives
           ? `<ul class="bullet-list">${content.programs.initiatives.map((item) => `<li>${safe(item)}</li>`).join("")}</ul>`
-
           : "") +
         (eventsHTML ? `<h3>${safe(content.programs.upcomingHeading || "Upcoming events")}</h3>${eventsHTML}` : "") +
         `</article>`
     );
   }
-
 
   if (content.faq) {
     fill(
@@ -177,6 +175,5 @@ export const renderStaticContent = (content, events = []) => {
         )
         .join("")}</div>`
     );
-
   }
 };

--- a/assets/js/directory.js
+++ b/assets/js/directory.js
@@ -7,18 +7,18 @@ export const renderDirectory = (ACCOUNTS)=>{
   const users = ACCOUNTS.filter(a=> a.role==="user");
   box.innerHTML = `
     <div style="display:flex; gap:8px; align-items:center; margin-bottom:10px">
-      <input id="dirFilter" placeholder="Search by name, phone, address..." style="flex:1; padding:8px; border-radius:8px; border:1px solid rgba(255,255,255,.18); background:rgba(255,255,255,.06); color:var(--text)">
+      <input id="dirFilter" placeholder="Search by name, phone, address..." style="flex:1; min-width:0">
       <span class="chip">${users.length} users</span>
     </div>
     <div class="gallery" id="dirGrid">
       ${users.map(u=>`
         <div class="tile" style="display:flex; gap:12px; align-items:center">
-          <div class="logo" style="width:54px;height:54px;border-radius:14px;color:#062031;display:grid;place-items:center">${initials(u.profile.name)}</div>
-          <div style="flex:1; min-width:0">
+          <div class="logo" style="width:54px;height:54px;border-radius:14px;display:grid;place-items:center">${initials(u.profile.name)}</div>
+          <div style="flex:1; min-width:0; display:grid; gap:4px">
             <div style="font-weight:800">${safe(u.profile.name)}</div>
-            <div style="color:#a8b5c6">${safe(u.profile.address)}</div>
-            <div style="color:#a8b5c6">${safe(u.profile.phone)}</div>
-            <div style="display:flex; gap:8px; margin-top:6px">
+            <div style="color:var(--muted)">${safe(u.profile.address)}</div>
+            <div style="color:var(--muted)">${safe(u.profile.phone)}</div>
+            <div style="display:flex; flex-wrap:wrap; gap:8px; margin-top:6px">
               <a class="btn" href="${telHref(u.profile.phone)}">Call</a>
               <a class="btn" href="mailto:${safe(u.profile.email)}">Email</a>
               <a class="btn" target="_blank" rel="noopener" href="${mapsHref(u.profile.address)}">Map</a>

--- a/assets/js/loans.js
+++ b/assets/js/loans.js
@@ -55,7 +55,7 @@ export const renderLoans = (ACCOUNTS)=>{
     const list = ACCOUNTS.filter(a=> a.role==="user");
     box.innerHTML = `
       <div style="display:flex; gap:8px; align-items:center; margin-bottom:10px">
-        <input id="flt" placeholder="Filter by name/phone/username" style="flex:1; padding:8px; border-radius:8px; border:1px solid rgba(255,255,255,.18); background:rgba(255,255,255,.06); color:var(--text)">
+        <input id="flt" placeholder="Filter by name/phone/username" style="flex:1; min-width:0">
         <span class="chip">${list.length} users</span>
       </div>
       <div class="table-wrap">

--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -3,7 +3,7 @@ export const money = (n) => {
   try { return new Intl.NumberFormat("en-IN", { style: "currency", currency: "INR", maximumFractionDigits: 0 }).format(n); }
   catch { return "₹" + Number(n || 0).toLocaleString("en-IN"); }
 };
-export const safe = (s="") => s.toString().replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));
+export const safe = (s="") => s.toString().replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c]));
 export const loadJSON = async (path) => {
   const res = await fetch(path, { cache: "no-store" });
   if (!res.ok) throw new Error("Failed to load " + path);

--- a/data/events.json
+++ b/data/events.json
@@ -1,20 +1,20 @@
 [
   {
-    "date": "2025-10-12",
-    "title": "Guru Jayanthi Rally",
-    "where": "Unit 9 Grounds",
-    "note": "Cultural procession, public meeting"
+    "date": "2025-10-20",
+    "title": "Pamba River Clean-up Sprint",
+    "where": "SNDP Hall, Chathenkery",
+    "note": "Morning riverbank sweep with flood-safety drill"
   },
   {
-    "date": "2025-11-02",
-    "title": "Scholarship Distribution",
-    "where": "Community Hall",
-    "note": "Merit & need\u2011based (demo)"
+    "date": "2025-11-08",
+    "title": "Pilgrim Transit Desk Training",
+    "where": "Chengannur Mahadevar Temple Transit Hub",
+    "note": "Briefing for Sabarimala season volunteers"
   },
   {
-    "date": "2025-12-14",
-    "title": "Health Camp",
-    "where": "Unit 9 Office",
-    "note": "Free basic screening"
+    "date": "2025-12-05",
+    "title": "Scholarship Mentoring Marathon",
+    "where": "Community Study Centre, Chathenkery",
+    "note": "Career guidance & digital literacy pods"
   }
 ]

--- a/data/notices.json
+++ b/data/notices.json
@@ -1,17 +1,17 @@
 [
   {
     "type": "warn",
-    "title": "AGM (Demo): 30 Nov 2025",
-    "body": "All members requested to attend. Quorum required."
+    "title": "Sabarimala Transit Volunteers",
+    "body": "Final orientation on 8 Nov, 4:00 p.m. at SNDP hall. Attendance required for ID badges."
   },
   {
     "type": "ok",
-    "title": "Flood Relief Collection",
-    "body": "Thanks to donors; materials dispatched to district control room."
+    "title": "Pamba River Watch",
+    "body": "Flood siren test scheduled for 18 Oct at 7:00 a.m.; residents please join the drill."
   },
   {
     "type": "ok",
-    "title": "Youth Wing Registration",
-    "body": "New intake for 2025\u201326 open till 31 Oct."
+    "title": "Community Library Hours",
+    "body": "Exam mentoring pods run every weekend 5:00–8:00 p.m. through December."
   }
 ]

--- a/data/site.json
+++ b/data/site.json
@@ -1,5 +1,152 @@
 {
-  "title": "SNDP Unit 9",
-  "motto": "One caste, one religion, one God, for humankind",
-  "theme": "dark"
+  "title": "SNDP Chathenkery",
+  "pageTitle": "SNDP Chathenkery — Community Hub",
+  "motto": "Riverfront sakha powering welfare, pilgrim care, and cooperative growth in Chengannur.",
+  "description": "Interactive portal for SNDP Chathenkery with SNDP Yogam history, programmes, pilgrim services, and member tools.",
+  "theme": "light",
+  "chips": [
+    "On the banks of the Pamba River in Chengannur",
+    "Gateway support point for Sabarimala pilgrims",
+    "Volunteer hours logged weekly by youth and women's wings"
+  ],
+  "stats": [
+    { "label": "Active families", "value": "480+", "note": "Annual membership renewals in Chathenkery ward" },
+    { "label": "Service hours", "value": "3.2k", "note": "Volunteer hours recorded for 2024–25 projects" },
+    { "label": "Study circles", "value": "12", "note": "Weekly social education & scripture pods" },
+    { "label": "Self-help groups", "value": "18", "note": "Women-led thrift and microfinance batches" }
+  ],
+  "highlights": [
+    {
+      "title": "Pamba riverside stewardship",
+      "body": "Community teams monitor the riverbanks connecting Chathenkery and Chengannur, pairing clean-ups with flood-readiness drills.",
+      "link": { "label": "View river watch schedule", "href": "https://maps.app.goo.gl/xxMPhtAVtHdxZfxb6", "external": true }
+    },
+    {
+      "title": "Gateway to Sabarimala care",
+      "body": "Pilgrim transit desks at Chengannur transport hubs extend the town’s role as the “Gateway to Sabarimala” with rest stops, maps, and first-aid.",
+      "link": { "label": "Pilgrim support plan", "href": "#/programs" }
+    },
+    {
+      "title": "Grassroots learning pods",
+      "body": "Youth mentors run evening digital literacy and language pods aligned with SNDP Yogam’s statewide education mission.",
+      "link": { "label": "Join a study circle", "href": "#/chathenkery" }
+    }
+  ],
+  "insights": [
+    {
+      "title": "2024–25 priority tracks",
+      "items": [
+        "Deploy solar lights around the SNDP hall and pilgrim rest centre.",
+        "Map vulnerable riverbank stretches with Chengannur Municipality.",
+        "Launch bilingual mentoring for Class 10 & 12 board exam cohorts."
+      ]
+    },
+    {
+      "title": "Community wellbeing indicators",
+      "items": [
+        "95 scholarship applications processed through the ward help desk.",
+        "40+ seniors receiving monthly wellness visits and mobility aid.",
+        "Six farmer clusters adopting organic manure through co-op ties."
+      ]
+    }
+  ],
+  "directoryIntro": {
+    "paragraphs": [
+      "Our directory keeps Chathenkery’s volunteer leads, youth convenors, and women’s wing accessible for pilgrim care and welfare programmes.",
+      "Reach out to coordinate river watch shifts, tuition pods, or municipal escalations across Chengannur’s riverbank wards."
+    ],
+    "list": [
+      "Pilgrim transit desks: duty rosters for Mahadeva Temple and railway station help centres.",
+      "Community welfare: scholarship mentoring, senior-care visits, and microfinance facilitation contacts."
+    ],
+    "cta": {
+      "label": "Email the ward secretary",
+      "href": "mailto:hello@sndpchathenkery.example.org"
+    }
+  },
+  "noticesIntro": {
+    "paragraphs": [
+      "Ward notices highlight pilgrim season briefings, flood-readiness drills, and community library timings so residents can plan ahead."
+    ],
+    "list": [
+      "Follow the November orientation to receive Sabarimala volunteer ID badges.",
+      "Join the October river siren test covering Chathenkery and neighbouring wards."
+    ]
+  },
+  "galleryIntro": {
+    "paragraphs": [
+      "Scenes from Chathenkery’s pilgrim gateways, Pamba stewardship drives, and learning pods capture the ward’s yellow-hued identity."
+    ]
+  },
+  "gallery": [
+    {
+      "eyebrow": "Pilgrim transit",
+      "title": "Chengannur Mahadeva Temple transit hub",
+      "body": "Volunteers guide Sabarimala-bound devotees at the Mahadeva Temple junction with route maps, rest points, and first-aid.",
+      "link": {
+        "label": "Transit help desk guide",
+        "href": "https://en.wikipedia.org/wiki/Chengannur_Mahadeva_Temple",
+        "external": true
+      }
+    },
+    {
+      "eyebrow": "River stewardship",
+      "title": "Pamba river clean-up corridors",
+      "body": "Youth teams pair shoreline clean-ups with water sampling to support the Pamba rejuvenation mission around Chengannur.",
+      "link": {
+        "label": "Kerala water mission update",
+        "href": "https://www.thehindu.com/news/national/kerala/pampa-rejuvenation-mission-begins/article24582896.ece",
+        "external": true
+      }
+    },
+    {
+      "eyebrow": "Community learning",
+      "title": "SNDP reading room and digital lab",
+      "body": "Study circles meet at the ward’s SNDP hall, blending Guru’s teachings with digital literacy modules for students and entrepreneurs.",
+      "link": {
+        "label": "Sree Narayana Guru teachings",
+        "href": "https://en.wikipedia.org/wiki/Sree_Narayana_Guru",
+        "external": true
+      }
+    }
+  ],
+  "loansIntro": {
+    "paragraphs": [
+      "The SNDP Chathenkery cooperative credit wing advances microloans that fund home repairs, education, and small enterprises across the ward.",
+      "Members can log in to review balances, repayment schedules, and the latest statements without leaving the neighbourhood office."
+    ],
+    "list": [
+      "Ward manager dashboard tracks balances, contact history, and overdue nudges.",
+      "User view summarises principal, interest, and closing balance month by month.",
+      "Download-ready data supports audits for Chengannur Municipality tie-ups."
+    ],
+    "cta": {
+      "label": "View cooperative policies",
+      "href": "#/notices",
+      "variant": "alt"
+    }
+  },
+  "referencesIntro": "Curated references grounding our Chathenkery profile and community projects.",
+  "references": [
+    {
+      "label": "Chengannur Tourism static site (GitHub)",
+      "href": "https://github.com/Jaisonemathew/chengannur",
+      "note": "Local landmarks and pilgrim context for the Chathenkery ward."
+    },
+    {
+      "label": "SNDP Yogam official site",
+      "href": "https://www.sndpyogam.org/",
+      "note": "Statewide programmes and institutional network."
+    },
+    {
+      "label": "Chengannur Mahadeva Temple — Wikipedia",
+      "href": "https://en.wikipedia.org/wiki/Chengannur_Mahadeva_Temple",
+      "note": "Pilgrim gateway context anchoring transit services in Chathenkery."
+    },
+    {
+      "label": "Pamba rejuvenation mission begins — The Hindu",
+      "href": "https://www.thehindu.com/news/national/kerala/pampa-rejuvenation-mission-begins/article24582896.ece",
+      "note": "State-led river restoration efforts that our ward clean-ups support."
+    }
+  ]
 }

--- a/data/users.json
+++ b/data/users.json
@@ -5,10 +5,10 @@
     "role": "manager",
     "profile": {
       "name": "Site Manager",
-      "address": "Unit 9 Office",
+      "address": "SNDP Chathenkery Office, Ward 3, Chengannur",
       "phone": "+91-90000-00000",
       "email": "manager@example.org",
-      "branch": "Unit 9"
+      "branch": "SNDP Chathenkery"
     },
     "loan": null
   },
@@ -18,10 +18,10 @@
     "role": "user",
     "profile": {
       "name": "Anil Kumar",
-      "address": "SNDP Unit 9, Example Rd, Kollam",
+      "address": "Chathenkery Ward 3, Chengannur Municipality",
       "phone": "+91-98950-10001",
       "email": "anil@example.org",
-      "branch": "Unit 9"
+      "branch": "SNDP Chathenkery"
     },
     "loan": {
       "amount_borrowed": 50000,
@@ -37,10 +37,10 @@
     "role": "user",
     "profile": {
       "name": "Lekshmi Das",
-      "address": "Unit 9, Ward 12, Kollam",
+      "address": "Pandavan Para Road, Chathenkery, Chengannur",
       "phone": "+91-98950-10002",
       "email": "lekshmi@example.org",
-      "branch": "Unit 9"
+      "branch": "SNDP Chathenkery"
     },
     "loan": {
       "amount_borrowed": 30000,
@@ -56,10 +56,10 @@
     "role": "user",
     "profile": {
       "name": "Harikrishnan",
-      "address": "Cheruvakkal, Kollam",
+      "address": "Kallissery Ferry Road, Chengannur",
       "phone": "+91-98950-10003",
       "email": "hari@example.org",
-      "branch": "Unit 9"
+      "branch": "SNDP Chathenkery"
     },
     "loan": {
       "amount_borrowed": 45000,
@@ -75,10 +75,10 @@
     "role": "user",
     "profile": {
       "name": "Sreedevi Raj",
-      "address": "Kadappakada, Kollam",
+      "address": "Thittamel, Chathenkery",
       "phone": "+91-98950-10004",
       "email": "sreedevi@example.org",
-      "branch": "Unit 9"
+      "branch": "SNDP Chathenkery"
     },
     "loan": {
       "amount_borrowed": 20000,
@@ -94,10 +94,10 @@
     "role": "user",
     "profile": {
       "name": "Vishnu Prasad",
-      "address": "Eravipuram, Kollam",
+      "address": "Mulakuzha Junction, Chengannur",
       "phone": "+91-98950-10005",
       "email": "vishnu@example.org",
-      "branch": "Unit 9"
+      "branch": "SNDP Chathenkery"
     },
     "loan": {
       "amount_borrowed": 60000,
@@ -113,10 +113,10 @@
     "role": "user",
     "profile": {
       "name": "Sneha Suresh",
-      "address": "Thrikkadavoor, Kollam",
+      "address": "Kurathikad, Chengannur",
       "phone": "+91-98950-10006",
       "email": "sneha@example.org",
-      "branch": "Unit 9"
+      "branch": "SNDP Chathenkery"
     },
     "loan": {
       "amount_borrowed": 25000,
@@ -132,10 +132,10 @@
     "role": "user",
     "profile": {
       "name": "Arjun Das",
-      "address": "Chinnakada, Kollam",
+      "address": "Thiruvalla Road, Chathenkery",
       "phone": "+91-98950-10007",
       "email": "arjun@example.org",
-      "branch": "Unit 9"
+      "branch": "SNDP Chathenkery"
     },
     "loan": {
       "amount_borrowed": 40000,
@@ -151,10 +151,10 @@
     "role": "user",
     "profile": {
       "name": "Beena Raj",
-      "address": "Pallimukku, Kollam",
+      "address": "Puthencavu, Chengannur",
       "phone": "+91-98950-10008",
       "email": "beena@example.org",
-      "branch": "Unit 9"
+      "branch": "SNDP Chathenkery"
     },
     "loan": {
       "amount_borrowed": 15000,
@@ -170,10 +170,10 @@
     "role": "user",
     "profile": {
       "name": "Jithin Kumar",
-      "address": "Kilikollur, Kollam",
+      "address": "Kodukulanji, Chengannur",
       "phone": "+91-98950-10009",
       "email": "jithin@example.org",
-      "branch": "Unit 9"
+      "branch": "SNDP Chathenkery"
     },
     "loan": {
       "amount_borrowed": 52000,
@@ -189,10 +189,10 @@
     "role": "user",
     "profile": {
       "name": "Reshma Rajesh",
-      "address": "Mayyanad, Kollam",
+      "address": "Puliyoor, Alappuzha",
       "phone": "+91-98950-10010",
       "email": "reshma@example.org",
-      "branch": "Unit 9"
+      "branch": "SNDP Chathenkery"
     },
     "loan": {
       "amount_borrowed": 22000,

--- a/index.html
+++ b/index.html
@@ -3,23 +3,27 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>SNDP Unit 9 — Site</title>
-  <meta name="description" content="SNDP Unit 9 website — clean, Wikipedia‑inspired design with directory, loans, and user detail pages."/>
+  <title>SNDP Chathenkery — Community Hub</title>
+  <meta name="description" content="SNDP Chathenkery community hub — interactive portal for Chengannur's riverfront ward with SNDP Yogam history, programmes, and member tools."/>
   <link rel="stylesheet" href="assets/css/main.css" />
 </head>
 <body>
   <header class="topbar">
     <a href="#/home" class="brand">
       <div class="logo">SN</div>
-      <span>SNDP Unit 9</span>
+      <span>SNDP Chathenkery</span>
     </a>
-    <nav class="nav">
+    <button id="navToggle" class="menu-toggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="primaryNav">
+      <span class="menu-icon" aria-hidden="true"></span>
+      <span class="menu-label">Menu</span>
+    </button>
+    <nav id="primaryNav" class="nav">
       <a href="#/home">Home</a>
-      <a href="#/about">About SNDP</a>
+      <a href="#/about">About SNDP Yogam</a>
       <a href="#/guru">Sree Narayana Guru</a>
       <a href="#/history">History</a>
-      <a href="#/unit9">Unit 9</a>
-      <a href="#/programs">Programs</a>
+      <a href="#/chathenkery">Chathenkery Unit</a>
+      <a href="#/programs">Programmes</a>
       <a href="#/directory">Directory</a>
       <a href="#/notices">Notices</a>
       <a href="#/gallery">Gallery</a>
@@ -28,12 +32,16 @@
       <a href="#/references">References</a>
     </nav>
     <div class="tools">
+      <button id="searchToggle" class="btn search-toggle" type="button" aria-expanded="false" aria-controls="q" title="Search pages">
+        <span class="search-icon" aria-hidden="true"></span>
+        <span class="search-text">Search</span>
+      </button>
       <label class="search">
         <input id="q" placeholder="Search pages... ( / )" />
       </label>
       <button id="theme" class="btn" title="Toggle theme">Theme</button>
       <button id="loginBtn" class="btn" title="Log in">Log in</button>
-      <div id="userPanel" style="display:none; gap:8px; align-items:center">
+      <div id="userPanel" style="display:none; gap:8px; align-items:center; flex-wrap:wrap">
         <span id="hello" style="font-weight:700"></span>
         <a class="btn" href="#/loans">Loan Portal</a>
         <button id="logoutBtn" class="btn" title="Log out">Log out</button>
@@ -44,34 +52,36 @@
   <main class="wrap">
     <section class="hero" data-route="home">
       <div class="hero-inner">
-        <div>
-          <h1>Welcome to SNDP Unit 9</h1>
-          <p>Wikipedia‑inspired layout • clean and modern UI • content sourced from public references.</p>
-          <div class="chips">
-            <span class="chip">Founded: 1903</span>
-            <span class="chip">HQ: Kollam, Kerala</span>
-            <span class="chip">Motto: “One caste, one religion, one God, for humankind”</span>
+        <div class="hero-copy">
+          <span class="eyebrow">Community hub</span>
+          <h1>Welcome to SNDP Chathenkery</h1>
+          <p id="siteMotto">Grassroots welfare hub for Chengannur’s Chathenkery ward.</p>
+          <div class="chips" id="homeChips">
+            <span class="chip">On the banks of the Pamba River</span>
+            <span class="chip">Gateway for Sabarimala pilgrims</span>
+            <span class="chip">Volunteer-driven welfare</span>
           </div>
-          <div class="cta" style="margin-top:10px">
-            <a class="btn" href="#/about">Explore About SNDP</a>
-            <a class="btn" href="#/unit9">Jump to Unit 9</a>
+          <div class="cta">
+            <a class="btn" href="#/about">Explore SNDP Yogam</a>
+            <a class="btn btn-alt" href="#/chathenkery">Discover Chathenkery Unit</a>
           </div>
         </div>
-        <div>
+        <div class="hero-spot">
           <div class="kpi" id="homeStats"></div>
-          <div class="notice ok"><div class="dot"></div><div><strong>Demo:</strong> Replace Unit‑9 placeholders with real data.</div></div>
+          <div class="notice ok"><div class="dot"></div><div><strong>Field update:</strong> Latest pilgrim-season services and river watch data are now live in the highlights below.</div></div>
         </div>
       </div>
-      <div id="homeOverview"></div>
+      <div id="homeOverview" class="home-highlights"></div>
+      <div id="homeInsights" class="home-insights"></div>
     </section>
 
     <section data-route="about"><h2>About SNDP</h2><div id="about"></div></section>
     <section data-route="guru"><h2>Sree Narayana Guru</h2><div id="guru"></div></section>
     <section data-route="history"><h2>History</h2><div id="history"></div></section>
-    <section data-route="unit9"><h2>Unit 9</h2><div id="unit9"></div></section>
-    <section data-route="programs"><h2>Programs</h2><div id="programs"></div></section>
+    <section data-route="chathenkery"><h2>SNDP Chathenkery</h2><div id="chathenkery"></div></section>
+    <section data-route="programs"><h2>Programmes</h2><div id="programs"></div></section>
     <section data-route="directory"><h2>Member Directory</h2><div id="directoryIntro"></div><div id="directoryView"></div></section>
-    <section data-route="notices"><h2>Notices & Events</h2><div id="noticesIntro"></div><div id="notices"></div></section>
+    <section data-route="notices"><h2>Notices &amp; Events</h2><div id="noticesIntro"></div><div id="notices"></div></section>
     <section data-route="gallery"><h2>Gallery</h2><div id="galleryIntro"></div><div id="galleryGrid" class="gallery"></div></section>
     <section data-route="faq"><h2>FAQ</h2><div id="faq"></div></section>
     <section data-route="loans"><h2>Loan Portal</h2><div id="loansIntro"></div><div id="loansView"></div></section>
@@ -79,7 +89,7 @@
     <section data-route="references"><h2>References</h2><div id="referencesIntro"></div><ol id="referencesList"></ol></section>
   </main>
 
-  <footer class="footer">© <span id="year"></span> SNDP Unit 9</footer>
+  <footer class="footer">© <span id="year"></span> SNDP Chathenkery</footer>
 
   <script type="module" src="assets/js/app.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- compress the mobile header layout by reordering the brand, menu toggle, and user tools with lighter padding and logo sizing
- add a mobile search toggle that reveals the search field on demand and closes alongside navigation changes
- ensure both navigation and search panels reset on route changes and viewport resize events

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e22c13d650832089964487565643f3