### PR TITLE
Fix theme initialization and sanitize stored routes

### DIFF
--- a/assets/js/router.js
+++ b/assets/js/router.js
@@ -1,12 +1,52 @@
 import { store } from "./util.js";
+
+const STATIC_ROUTES = new Set([
+  "home",
+  "about",
+  "guru",
+  "history",
+  "chathenkery",
+  "programs",
+  "directory",
+  "notices",
+  "gallery",
+  "faq",
+  "loans",
+  "references",
+  "login"
+]);
+
+const clean = (route = "") => String(route || "").replace(/^#\//, "");
+
+export const normalizeRoute = (route = "") => {
+  const value = clean(route);
+  if(!value){ return "home"; }
+  const [root, param] = value.split("/");
+  if(root === "user" && param){
+    return `user/${param}`;
+  }
+  if(STATIC_ROUTES.has(root)){
+    return root;
+  }
+  return "home";
+};
+
+export const isValidRoute = (route = "") => {
+  const cleaned = clean(route);
+  if(!cleaned){ return false; }
+  return normalizeRoute(cleaned) === cleaned;
+};
+
 export const currentRoute = () => {
-  const hash = location.hash.startsWith("#/") ? location.hash.slice(2) : "home";
-  const [root, param] = hash.split("/");
+  const normalized = normalizeRoute(location.hash.startsWith("#/") ? location.hash.slice(2) : "");
+  const [root, param] = normalized.split("/");
   return { root: root || "home", param };
 };
+
 export const renderRoute = () => {
   const { root, param } = currentRoute();
   const key = (root === "user" && param) ? "user" : root;
+  const normalized = (root === "user" && param) ? `user/${param}` : root;
   document.querySelectorAll("[data-route]").forEach(el => {
     el.style.display = (el.getAttribute("data-route") === key) ? "block" : "none";
   });
@@ -14,5 +54,5 @@ export const renderRoute = () => {
     a.classList.toggle("active", a.getAttribute("href") === "#/" + key);
   });
   // route hooks are executed by app.js (after data loads)
-  store.set("lastRoute", key + (param ? "/" + param : ""));
+  store.set("lastRoute", normalized);
 };

--- a/data/site.json
+++ b/data/site.json
@@ -3,7 +3,7 @@
   "pageTitle": "SNDP Chathenkery — Community Hub",
   "motto": "Riverfront sakha powering welfare, pilgrim care, and cooperative growth in Chengannur.",
   "description": "Interactive portal for SNDP Chathenkery with SNDP Yogam history, programmes, pilgrim services, and member tools.",
-  "theme": "light",
+  "theme": "sunrise",
   "chips": [
     "On the banks of the Pamba River in Chengannur",
     "Gateway support point for Sabarimala pilgrims",

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <meta name="description" content="SNDP Chathenkery community hub — interactive portal for Chengannur's riverfront ward with SNDP Yogam history, programmes, and member tools."/>
   <link rel="stylesheet" href="assets/css/main.css" />
 </head>
-<body data-nav-open="false" data-search-open="false">
+<body data-nav-open="false" data-search-open="false" data-theme="sunrise">
   <header class="topbar">
     <a href="#/home" class="brand">
       <div class="logo">SN</div>


### PR DESCRIPTION
## Summary
- default the SPA to the updated sunrise theme and keep the toggle cycling between sunrise and dark
- normalize stored and incoming routes so stale hashes like `#/unit9` fall back to valid sections
- set the HTML shell and site config to use the sunrise theme branding

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e2428f8ff08320891815651098ca79